### PR TITLE
Fix: Version Issues

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -23,12 +23,12 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
-      <version>0.11.0</version>
+      <version>1.7.1</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-extension-annotations</artifactId>
-      <version>0.11.0</version>
+      <version>1.7.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
`import io.opentelemetry.api.GlobalOpenTelemetry;` not part of the earlier version 0.11.

I was trying to play around with the examples and found that there is an issue with the older version of annotator. `GlobalOpenTelemetry` was added recently.